### PR TITLE
fix: path decoding corruption, launch endpoint, and stream cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- **Path decoding**: Windows project directory names with literal hyphens (e.g. `fiscal-26`) are now preserved instead of being split into bogus path segments (`fiscal/26`). The decoder uses `--` as the reliable separator boundary when present, keeping single `-` as literal hyphens.
+- **Session launch**: `LaunchButton` now reads `cwd` from the JSONL session data instead of using the lossy decoded project path. The launch endpoint reads the first 4KB (multiple lines) instead of just the first line to find the `cwd` field.
+- **Stream cleanup**: `search.api.ts` and `session-parser.ts` now use `try/finally` blocks to properly close readline streams and destroy file handles, preventing resource leaks on early returns.
+
+### Migration
+
+After upgrading, pinned/hidden/renamed project settings in `~/.claude-dashboard/session-metadata.json` may use old path keys. These won't match the new decoder output. Either:
+1. Delete the file to reset (you'll lose pins/hides/renames)
+2. Run a key migration to remap old paths to new paths

--- a/apps/web/src/features/sessions/SessionCard.tsx
+++ b/apps/web/src/features/sessions/SessionCard.tsx
@@ -173,7 +173,7 @@ export function SessionCard({ session, metadata, projectMeta }: SessionCardProps
 
         <div className="flex shrink-0 items-center gap-1.5">
           <HideButton projectPath={session.projectPath} />
-          <LaunchButton sessionId={session.sessionId} cwd={session.projectPath} />
+          <LaunchButton sessionId={session.sessionId} cwd={session.cwd || session.projectPath} />
           <OverflowMenu
             sessionId={session.sessionId}
             onStartRename={() => setIsRenaming(true)}

--- a/apps/web/src/features/sessions/search.api.ts
+++ b/apps/web/src/features/sessions/search.api.ts
@@ -69,36 +69,38 @@ async function searchFile(filePath: string, query: string): Promise<{ snippet: s
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' })
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
 
-  for await (const line of rl) {
-    if (!line.trim()) continue
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let msg: any
-    try {
-      msg = JSON.parse(line)
-    } catch (_) {
-      continue
-    }
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) continue
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let msg: any
+      try {
+        msg = JSON.parse(line)
+      } catch (_) {
+        continue
+      }
 
-    if (msg.type !== 'user' && msg.type !== 'assistant') continue
-    const content = msg.message?.content
-    if (!content || !Array.isArray(content)) continue
+      if (msg.type !== 'user' && msg.type !== 'assistant') continue
+      const content = msg.message?.content
+      if (!content || !Array.isArray(content)) continue
 
-    for (const block of content) {
-      if (block.type === 'text' && block.text) {
-        const text = block.text as string
-        const idx = text.toLowerCase().indexOf(query)
-        if (idx !== -1) {
-          // Extract snippet around the match
-          const start = Math.max(0, idx - 40)
-          const end = Math.min(text.length, idx + query.length + 80)
-          const snippet = (start > 0 ? '...' : '') + text.slice(start, end).trim() + (end < text.length ? '...' : '')
-          rl.close()
-          stream.destroy()
-          return { snippet, timestamp: (msg.timestamp as string) ?? '' }
+      for (const block of content) {
+        if (block.type === 'text' && block.text) {
+          const text = block.text as string
+          const idx = text.toLowerCase().indexOf(query)
+          if (idx !== -1) {
+            const start = Math.max(0, idx - 40)
+            const end = Math.min(text.length, idx + query.length + 80)
+            const snippet = (start > 0 ? '...' : '') + text.slice(start, end).trim() + (end < text.length ? '...' : '')
+            return { snippet, timestamp: (msg.timestamp as string) ?? '' }
+          }
         }
       }
     }
-  }
 
-  return null
+    return null
+  } finally {
+    rl.close()
+    stream.destroy()
+  }
 }

--- a/apps/web/src/lib/parsers/session-parser.ts
+++ b/apps/web/src/lib/parsers/session-parser.ts
@@ -156,7 +156,8 @@ export async function parseDetail(
   const stream = fs.createReadStream(filePath, { encoding: 'utf-8' })
   const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
 
-  for await (const line of rl) {
+  try {
+    for await (const line of rl) {
     const msg = safeParse(line)
     if (!msg || msg.type === 'file-history-snapshot') continue
 
@@ -445,6 +446,10 @@ export async function parseDetail(
         toolCalls,
       })
     }
+  }
+  } finally {
+    rl.close()
+    stream.destroy()
   }
 
   // Merge accumulated progress stats into agents

--- a/apps/web/src/lib/utils/claude-path.test.ts
+++ b/apps/web/src/lib/utils/claude-path.test.ts
@@ -90,11 +90,13 @@ describe('claude-path', () => {
   })
 
   describe('decodeProjectDirName', () => {
-    it('decodes leading dash to slash', () => {
+    // --- Unix paths (no double-dash) ---
+
+    it('decodes leading dash to slash (Unix)', () => {
       expect(decodeProjectDirName('-Users-username-project')).toBe('/Users/username/project')
     })
 
-    it('decodes a typical encoded project directory name', () => {
+    it('decodes a typical encoded Unix project directory name', () => {
       expect(decodeProjectDirName('-Users-alice-Documents-GitHub-myproject')).toBe(
         '/Users/alice/Documents/GitHub/myproject'
       )
@@ -104,20 +106,53 @@ describe('claude-path', () => {
       expect(decodeProjectDirName('-project')).toBe('/project')
     })
 
-    it('converts all dashes to slashes after leading dash is replaced', () => {
+    it('converts all dashes to slashes for pure Unix paths', () => {
       const result = decodeProjectDirName('-a-b-c-d')
       expect(result).toBe('/a/b/c/d')
     })
 
-    it('handles a path with no dashes (returns string unchanged if no leading dash)', () => {
-      // No leading dash means no replacement of leading char
+    it('handles a path with no dashes (returns string unchanged)', () => {
       const result = decodeProjectDirName('nodash')
       expect(result).toBe('nodash')
     })
 
-    it('handles deep nested paths', () => {
+    it('handles deep nested Unix paths', () => {
       expect(decodeProjectDirName('-home-user-work-clients-acme-frontend')).toBe(
         '/home/user/work/clients/acme/frontend'
+      )
+    })
+
+    // --- Windows paths (double-dash present) ---
+
+    it('decodes Windows drive letter with double-dash', () => {
+      expect(decodeProjectDirName('C--Users-godot--work')).toBe('C:/Users-godot/work')
+    })
+
+    it('preserves literal hyphens in folder names on Windows', () => {
+      expect(decodeProjectDirName('C--Users-godot--work-fiscal-26')).toBe(
+        'C:/Users-godot/work-fiscal-26'
+      )
+    })
+
+    it('preserves hyphens in nested Windows paths', () => {
+      expect(decodeProjectDirName('C--Users-godot--work-fiscal-26-forms')).toBe(
+        'C:/Users-godot/work-fiscal-26-forms'
+      )
+    })
+
+    it('handles Windows OneDrive paths with underscore dirs', () => {
+      expect(decodeProjectDirName('C--Users-godot-OneDrive--LIVE--CODE-quickfax')).toBe(
+        'C:/Users-godot-OneDrive/LIVE/CODE-quickfax'
+      )
+    })
+
+    it('handles Windows root path', () => {
+      expect(decodeProjectDirName('C--')).toBe('C:/')
+    })
+
+    it('handles Unix path with double-dash (underscore dirs)', () => {
+      expect(decodeProjectDirName('-home-user--work-my-project')).toBe(
+        '/home-user/work-my-project'
       )
     })
   })

--- a/apps/web/src/lib/utils/claude-path.ts
+++ b/apps/web/src/lib/utils/claude-path.ts
@@ -32,7 +32,29 @@ export function getHistoryPath(): string {
  * which maps to "/Users/username/Documents/GitHub/foo"
  */
 export function decodeProjectDirName(dirName: string): string {
-  // Replace leading dash with / and all other dashes with /
+  // Claude Code's encoding is lossy: \, /, :, _, and literal - all become -
+  // When -- exists, it reliably marks a path separator or special char boundary,
+  // so single - can be kept as a literal hyphen (preserves names like fiscal-26).
+  // When no -- exists (pure Unix paths), every - is a path separator.
+
+  const hasDoubleDash = dirName.includes('--')
+
+  if (hasDoubleDash) {
+    // Windows-style path: "C--Users-godot--work-fiscal-26"
+    const driveMatch = dirName.match(/^([A-Za-z])--(.*)$/)
+    if (driveMatch) {
+      const rest = driveMatch[2].replace(/--/g, '/').replace(/-/g, '-')
+      return `${driveMatch[1].toUpperCase()}:/${rest}`
+    }
+    // Unix path with special chars (e.g. underscore dirs): "--" marks separators
+    if (dirName.startsWith('-')) {
+      const rest = dirName.slice(1).replace(/--/g, '/').replace(/-/g, '-')
+      return `/${rest}`
+    }
+    return dirName.replace(/--/g, '/').replace(/-/g, '-')
+  }
+
+  // No double-dash: plain Unix path, every - is a path separator
   return dirName.replace(/^-/, '/').replace(/-/g, '/')
 }
 

--- a/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx
@@ -208,7 +208,7 @@ function SessionDetailPage() {
         <div className="flex items-center gap-2">
           <DetailPinButton sessionId={sessionId} pinned={sessionMeta?.pinned ?? false} />
           <DetailRenameButton sessionId={sessionId} currentName={sessionMeta?.customName || ''} />
-          <LaunchButton sessionId={sessionId} cwd={detail.projectPath} size="md" />
+          <LaunchButton sessionId={sessionId} cwd={detail.cwd || detail.projectPath} size="md" />
           <ExportDropdown
             options={[
               {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,7 +6,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { spawn, execSync } from 'node:child_process'
 import { homedir, tmpdir, platform } from 'node:os'
 import { join } from 'node:path'
-import { readdirSync, existsSync, readFileSync, writeFileSync, unlinkSync, chmodSync } from 'node:fs'
+import { readdirSync, existsSync, readFileSync, writeFileSync, unlinkSync, chmodSync, openSync, readSync, closeSync } from 'node:fs'
 
 function launchSessionPlugin(): Plugin {
   return {
@@ -31,11 +31,19 @@ function launchSessionPlugin(): Plugin {
               for (const d of dirs) {
                 const jsonl = join(projDir, d, sessionId + '.jsonl')
                 if (existsSync(jsonl)) {
-                  const firstLine = readFileSync(jsonl, 'utf8').split('\n')[0]
-                  try {
-                    const parsed = JSON.parse(firstLine)
-                    if (parsed.cwd) { sessionCwd = parsed.cwd; break }
-                  } catch {}
+                  const fd = openSync(jsonl, 'r')
+                  const buf = Buffer.alloc(4096)
+                  const bytesRead = readSync(fd, buf, 0, 4096, 0)
+                  closeSync(fd)
+                  const headLines = buf.toString('utf8', 0, bytesRead).split('\n')
+                  for (const headLine of headLines) {
+                    if (!headLine.trim()) continue
+                    try {
+                      const parsed = JSON.parse(headLine)
+                      if (parsed.cwd) { sessionCwd = parsed.cwd; break }
+                    } catch {}
+                  }
+                  if (sessionCwd !== (cwd || home)) break
                 }
               }
             } catch {}


### PR DESCRIPTION
## Summary
- **Path decoder**: `decodeProjectDirName` now preserves literal hyphens in project names (e.g. `fiscal-26` stays `fiscal-26`, not `fiscal/26`). Uses `--` as reliable separator boundary for Windows paths; falls back to old behavior for Unix paths.
- **LaunchButton**: Uses `session.cwd` (real path from JSONL) instead of the lossy decoded `projectPath` for launch, with fallback.
- **Launch endpoint**: Reads first 4KB of JSONL (buffer-based) instead of only the first line, since `cwd` is rarely on line 1.
- **Stream cleanup**: `search.api.ts` and `session-parser.ts` now use `try/finally` for proper `rl.close()` + `stream.destroy()` cleanup.

## How the decoder works

Claude Code encodes project paths as directory names where `\`, `/`, `:`, `_` and literal `-` all become `-`. This is lossy — you can't distinguish a path separator from a real hyphen.

The heuristic: when `--` exists in the name (Windows paths always have it from `C:\` -> `C--`), treat `--` as path separator and keep single `-` as literal hyphen. Pure Unix paths (no `--`) use the old every-dash-is-a-separator behavior.

| Encoded dir name | Old (broken) | New (fixed) |
|---|---|---|
| `C--Users-godot--work-fiscal-26` | `C//Users/godot//work/fiscal/26` | `C:/Users-godot/work-fiscal-26` |
| `C--Users-godot-OneDrive--LIVE--CODE-detectd-app` | `C//Users/godot/OneDrive//LIVE//CODE/detectd/app` | `C:/Users-godot-OneDrive/LIVE/CODE-detectd-app` |

Display names are unaffected because `extractProjectName` filters noise segments (`Users`, `godot`, `C`, etc.).

## Metadata migration

After upgrading, `~/.claude-dashboard/session-metadata.json` project keys use old decoded paths. Pins/hides/renames won't match. A migration script remaps keys by decoding each `~/.claude/projects/` dir with both old and new decoders.

## Test plan
- [x] TypeScript typecheck passes
- [x] Tests pass (pre-existing platform failures excluded)
- [x] Updated decoder tests cover Windows drive paths, literal hyphens, OneDrive paths
- [x] CHANGELOG added documenting all changes
- [x] Manual: `fiscal-26` displays correctly with hyphen
- [x] Manual: Launch button opens correct directory
- [x] Manual: Metadata migration applied and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)