### PR TITLE
Fix app-wide hydration warning + render-purity lint errors

### DIFF
--- a/apps/web/src/components/TerminalLoader.tsx
+++ b/apps/web/src/components/TerminalLoader.tsx
@@ -32,7 +32,7 @@ export function TerminalLoader() {
   const [spinnerIdx, setSpinnerIdx] = useState(0)
   const [phraseIdx, setPhraseIdx] = useState(0)
   const [dots, setDots] = useState('')
-  const [logLines, setLogLines] = useState<string[]>([])
+  const [logLines, setLogLines] = useState<{ id: number; text: string }[]>([])
   const [cursorVisible, setCursorVisible] = useState(true)
   const logIdxRef = useRef(0)
 
@@ -70,8 +70,9 @@ export function TerminalLoader() {
     const addLine = () => {
       const line = LOG_LINES[logIdxRef.current % LOG_LINES.length]
       const formatted = line.replace('%d', String(Math.floor(Math.random() * 400) + 50))
+      const id = logIdxRef.current
       setLogLines((prev) => {
-        const next = [...prev, formatted]
+        const next = [...prev, { id, text: formatted }]
         return next.length > 6 ? next.slice(-6) : next
       })
       logIdxRef.current++
@@ -107,17 +108,17 @@ export function TerminalLoader() {
           <span>loading</span>
         </div>
         <div className="space-y-1">
-          {logLines.map((line, i) => {
+          {logLines.map((item, i) => {
             const isLatest = i === logLines.length - 1
             return (
               <div
-                key={`${logIdxRef.current - logLines.length + i}`}
+                key={item.id}
                 className="flex gap-2 transition-opacity duration-300"
                 style={{ opacity: isLatest ? 1 : 0.4 }}
               >
                 <span className="text-matrix/50 select-none">{'>'}</span>
                 <span className={isLatest ? 'text-matrix/90' : 'text-matrix/30'}>
-                  {line}
+                  {item.text}
                 </span>
               </div>
             )

--- a/apps/web/src/features/sessions/StatusBadge.tsx
+++ b/apps/web/src/features/sessions/StatusBadge.tsx
@@ -1,19 +1,19 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 
 type SessionState = 'working' | 'waiting' | 'inactive'
 
 const SPINNER_CHARS = ['\u280B', '\u2819', '\u2839', '\u2838', '\u283C', '\u2834', '\u2826', '\u2827', '\u2807', '\u280F']
 
 function BrailleSpinner({ offset }: { offset: number }) {
+  // Start phase-shifted by `offset`, then advance one frame per tick. Avoids
+  // Date.now() during render (impure) \u2014 the per-tick increment is equivalent.
   const [frame, setFrame] = useState(offset % SPINNER_CHARS.length)
-  const startRef = useRef(Date.now())
   useEffect(() => {
     const id = setInterval(() => {
-      const elapsed = Date.now() - startRef.current
-      setFrame((offset + Math.floor(elapsed / 80)) % SPINNER_CHARS.length)
+      setFrame((f) => (f + 1) % SPINNER_CHARS.length)
     }, 80)
     return () => clearInterval(id)
-  }, [offset])
+  }, [])
   return <span>{SPINNER_CHARS[frame]}</span>
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -71,7 +71,7 @@ const themeInitScript = `
 
 function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />


### PR DESCRIPTION
Follow-up to #46 (the flagged hydration warning) + greens the CI lint gate.

- **Hydration**:  init script set data-theme on <html> pre-hydration; SSR had none -> warning on every route. Added suppressHydrationWarning to <html>. Verified 0 hydration warnings on /settings, /dashboard, /sessions.
- **Lint (CI gate)**: removed Date.now() during render in StatusBadge BrailleSpinner and ref-access-during-render in TerminalLoader log key. eslint src/ now 0 errors (was 2).

Verified: tsc clean, 458/458 tests, 0 console errors live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)