### PR TITLE
fix(build): production SSR crashed with 'jsxDEV is not a function'

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ npx vite --port 3030      # dev server
 npx vitest                 # tests
 ```
 
-> **Note**: Production build has a known TanStack Start issue on Node v24. Use dev mode (`npx vite`).
+> **Note**: Both dev mode (`npx vite --port 3030`) and the production build (`npm run build` then `npm start`) work. The in-app **Launch session** button only works in dev mode, since its endpoint runs as Vite dev-server middleware.
 
 ---
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -163,20 +163,30 @@ function launchSessionPlugin(): Plugin {
   }
 }
 
-export default defineConfig({
-  server: {
-    port: 3000,
-    watch: {
-      ignored: ['**/routeTree.gen.ts'],
+export default defineConfig(({ command }) => {
+  // Production builds must use React's production JSX transform. Vite defaults
+  // builds to mode=production, but @vitejs/plugin-react keys its dev-vs-prod JSX
+  // runtime on process.env.NODE_ENV — if it's unset, the SSR bundle emits
+  // `jsxDEV` and the built server crashes at runtime ("jsxDEV is not a
+  // function"). Pin NODE_ENV=production for builds (respect an explicit override).
+  if (command === 'build' && !process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'production'
+  }
+  return {
+    server: {
+      port: 3000,
+      watch: {
+        ignored: ['**/routeTree.gen.ts'],
+      },
     },
-  },
-  plugins: [
-    launchSessionPlugin(),
-    tsConfigPaths(),
-    tanstackStart(),
-    viteReact(),
-    tailwindcss(),
-  ],
-  // Test config is in vitest.config.ts (separate from app config to avoid
-  // tanstackStart/viteReact plugins interfering with React module resolution in tests)
+    plugins: [
+      launchSessionPlugin(),
+      tsConfigPaths(),
+      tanstackStart(),
+      viteReact(),
+      tailwindcss(),
+    ],
+    // Test config is in vitest.config.ts (separate from app config to avoid
+    // tanstackStart/viteReact plugins interfering with React module resolution in tests)
+  }
 })


### PR DESCRIPTION
Fixes the long-standing "production build broken on Node 24" issue (README note).

## Root cause
The production build was emitting React's **dev** JSX runtime — the built SSR bundle imported `react/jsx-dev-runtime` and called `jsxDEV` 14x, so `node bin/cli.mjs` returned **HTTP 500** on every page (`TypeError: jsxDEV is not a function` at `RootComponent`). The build *succeeds* (so CI's build job is green), only *serving* crashes — which is why it went unnoticed and got mislabeled a Node-24 problem.

`@vitejs/plugin-react` selects its dev-vs-prod JSX runtime from `process.env.NODE_ENV`; `vite build` leaves it unset (mode=production alone is not enough), so the dev transform leaked into the prod bundle.

## Fix
Pin `NODE_ENV=production` for the `build` command in `vite.config.ts` (respects an explicit override). Zero new deps, cross-platform.

## Verified
- Plain `vite build` (NODE_ENV unset, as CI runs it): **0** `jsxDEV` in `dist/server`.
- `node bin/cli.mjs`: `/dashboard` and `/sessions` -> **200**, zero runtime errors.
- `tsc` clean, 458/458 tests.

Note: the in-app **Launch** button still only works in dev mode (its endpoint is Vite middleware) — documented in the README; separate follow-up if we want it in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)