### PR TITLE
test(e2e): fix 8 stale E2E tests (dashboard-overhaul drift) — suite green

### DIFF
--- a/apps/web/e2e/tests/navigation.spec.ts
+++ b/apps/web/e2e/tests/navigation.spec.ts
@@ -1,22 +1,22 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Navigation', () => {
-  test('Given the app is loaded, When I visit the root URL, Then I am redirected to /sessions', async ({
+  test('Given the app is loaded, When I visit the root URL, Then I am redirected to /dashboard', async ({
     page,
   }) => {
     await page.goto('/')
-    await expect(page).toHaveURL(/\/sessions/)
+    await expect(page).toHaveURL(/\/dashboard/)
   })
 
-  test('Given I am on sessions, When I click "Stats", Then I see the Stats page', async ({
+  test('Given I am on sessions, When I click "Dashboard", Then I see the Dashboard page', async ({
     page,
   }) => {
     await page.goto('/sessions')
-    await page.click('a[href="/stats"]')
-    await expect(page).toHaveURL(/\/stats/)
-    await expect(page.locator('h1')).toContainText('Stats')
+    await page.getByRole('link', { name: 'Dashboard', exact: true }).click()
+    await expect(page).toHaveURL(/\/dashboard/)
+    await expect(page.locator('h1')).toContainText('Dashboard')
     await page.screenshot({
-      path: 'e2e/screenshots/stats-page.png',
+      path: 'e2e/screenshots/dashboard-page.png',
       fullPage: true,
     })
   })

--- a/apps/web/e2e/tests/sessions.spec.ts
+++ b/apps/web/e2e/tests/sessions.spec.ts
@@ -65,14 +65,14 @@ test.describe('Sessions List', () => {
     }
   })
 
-  test('Given I am on /sessions, When I view a session card, Then it shows model, branch, and duration info', async ({
+  test('Given I am on /sessions, When I view a session card, Then it shows model and message info', async ({
     page,
   }) => {
     const firstCard = page.locator('a[href*="/sessions/session-"]').first()
     const cardText = await firstCard.textContent()
     // Should have a model name (displayed as shortened version like "sonnet-4")
     expect(cardText).toMatch(/sonnet|haiku|opus/i)
-    // Should have branch info
-    expect(cardText).toMatch(/main|feature|develop/i)
+    // Should show the message count (e.g. "4 msgs")
+    expect(cardText).toMatch(/\d+\s*msg/i)
   })
 })

--- a/apps/web/e2e/tests/stats.spec.ts
+++ b/apps/web/e2e/tests/stats.spec.ts
@@ -1,40 +1,43 @@
 import { test, expect } from '@playwright/test'
 
-test.describe('Stats Page', () => {
+// The former /stats route now redirects to /dashboard, which hosts the stats
+// summary cards (Sessions / Messages / Tokens / Cost) and the charts.
+test.describe('Stats (Dashboard)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/stats')
-    // Wait for stats to load (summary cards appear)
-    await page.waitForSelector('text=Total Sessions', { timeout: 15_000 })
+    // /stats redirects to /dashboard; wait for a chart that only renders once
+    // stats have loaded.
+    await page.waitForSelector('text=Model Usage', { timeout: 15_000 })
   })
 
-  test('Given stats-cache.json exists in fixtures, When I visit /stats, Then I see summary cards', async ({
+  test('Given stats-cache.json exists in fixtures, When I visit the dashboard, Then I see summary cards', async ({
     page,
   }) => {
-    await expect(page.getByText('Total Sessions').first()).toBeVisible()
-    await expect(page.getByText('Total Messages').first()).toBeVisible()
-    await expect(page.getByText('Total Tokens').first()).toBeVisible()
-    await expect(page.getByText('Longest Session').first()).toBeVisible()
+    const main = page.locator('main')
+    await expect(main.getByText('Sessions').first()).toBeVisible()
+    await expect(main.getByText('Messages').first()).toBeVisible()
+    await expect(main.getByText('Tokens').first()).toBeVisible()
+    await expect(main.getByText('Cost').first()).toBeVisible()
     await page.screenshot({
       path: 'e2e/screenshots/stats-overview.png',
       fullPage: true,
     })
   })
 
-  test('Given stats data exists, When I view the stats page, Then I see "3" as total sessions', async ({
+  test('Given stats data exists, Then the Sessions card shows "3" total sessions', async ({
     page,
   }) => {
-    // The stat card for Total Sessions should contain the value "3"
-    const totalSessionsCard = page
-      .locator('div.rounded-xl')
-      .filter({ hasText: 'Total Sessions' })
+    // The Sessions summary card links to /sessions and shows the total (3).
+    const sessionsCard = page
+      .locator('main a[href="/sessions"]')
+      .filter({ hasText: 'Sessions' })
       .first()
-    await expect(totalSessionsCard).toContainText('3')
+    await expect(sessionsCard).toContainText('3')
   })
 
   test('Given stats data exists, Then I see the Daily Activity chart rendered', async ({
     page,
   }) => {
-    // Activity chart has heading "Daily Activity"
     await expect(page.getByText('Daily Activity').first()).toBeVisible()
   })
 


### PR DESCRIPTION
The CI **E2E** job has been red on **pre-existing** stale tests from the 4-tab dashboard overhaul (unrelated to recent PRs #46/#47/#48 — `git diff` shows those never touched e2e or routing). Recent merges just re-ran CI for the first time since the overhaul and surfaced them.

## Fixed (8 tests)
- **navigation**: `/` redirects to `/dashboard` (was `/sessions`); replaced the dead "Stats" nav-link test (no such link now) with a Dashboard-nav test.
- **sessions**: card shows model + message count (SessionCard no longer renders a git branch).
- **stats (5)**: `/stats` now redirects to `/dashboard`; assert the real summary labels (Sessions/Messages/Tokens/Cost), the "3" sessions total, and the Daily Activity / Model Usage charts.

## Verified
Full Playwright suite **24/24 passing** against `e2e/fixtures/.claude`; `tsc` clean. This greens the E2E CI job and stops the failure-notification emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)